### PR TITLE
Added test for user type defined by implementing org.hibernate.type.U…

### DIFF
--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/Gene.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/Gene.java
@@ -1,0 +1,32 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.jboss.as.test.compat.jpa.hibernate.transformer;
+
+/**
+ * @author Paolo Perrotta
+ */
+public class Gene {
+
+    private Integer id;
+    private State state;
+
+    public State getState() {
+        return state;
+    }
+
+    public void setState(State state) {
+        this.state = state;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/SFSBHibernateSessionFactory.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/SFSBHibernateSessionFactory.java
@@ -187,4 +187,35 @@ public class SFSBHibernateSessionFactory {
         }
 
     }
+
+    public Gene createGene(int id, State state) {
+        final Gene gene = new Gene();
+        gene.setId( id );
+        gene.setState( state );
+        try {
+            Session session = sessionFactory.openSession();
+            Transaction tx = session.beginTransaction();
+            session.save( gene );
+            session.flush();
+            tx.commit();
+            session.close();
+        } catch (Exception e) {
+            throw new RuntimeException("transactional failure while persisting gene entity", e);
+        }
+
+        return gene;
+    }
+
+    public Gene getGene(int id) {
+        try {
+            Session session = sessionFactory.openSession();
+            Transaction tx = session.beginTransaction();
+            Gene gene = session.get( Gene.class, id );
+            tx.commit();
+            session.close();
+            return gene;
+        } catch (Exception e) {
+            throw new RuntimeException("transactional failure while getting gene entity", e);
+        }
+   }
 }

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/State.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/State.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+//$Id$
+package org.jboss.as.test.compat.jpa.hibernate.transformer;
+
+
+/**
+ * @author Emmanuel Bernard
+ */
+public enum State {
+    ACTIVE,
+    DORMANT
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/StateType.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/StateType.java
@@ -1,0 +1,77 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+//$Id$
+package org.jboss.as.test.compat.jpa.hibernate.transformer;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.usertype.UserType;
+
+/**
+ * @author Emmanuel Bernard
+ */
+public class StateType implements UserType {
+    public int[] sqlTypes() {
+        return new int[] {
+            Types.INTEGER
+        };
+    }
+
+    public Class returnedClass() {
+        return State.class;
+    }
+
+    public boolean equals(Object x, Object y) throws HibernateException {
+        return x == y;
+    }
+
+    public int hashCode(Object x) throws HibernateException {
+        return x.hashCode();
+    }
+
+    public Object nullSafeGet(ResultSet rs, String[] names, SessionImplementor session, Object owner) throws HibernateException, SQLException {
+        int result = rs.getInt( names[0] );
+        if ( rs.wasNull() ) return null;
+        return State.values()[result];
+    }
+
+    public void nullSafeSet(PreparedStatement st, Object value, int index, SessionImplementor session) throws HibernateException, SQLException {
+        if (value == null) {
+            st.setNull( index, Types.INTEGER );
+        }
+        else {
+            st.setInt( index, ( (State) value ).ordinal() );
+        }
+    }
+
+    public Object deepCopy(Object value) throws HibernateException {
+        return value;
+    }
+
+    public boolean isMutable() {
+        return false;
+    }
+
+    public Serializable disassemble(Object value) throws HibernateException {
+        return (Serializable) value;
+    }
+
+    public Object assemble(Serializable cached, Object owner) throws HibernateException {
+        return cached;
+    }
+
+    public Object replace(Object original, Object target, Object owner) throws HibernateException {
+        return original;
+    }
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/VerifyHibernate51CompatibilityTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/VerifyHibernate51CompatibilityTestCase.java
@@ -72,7 +72,11 @@ public class VerifyHibernate51CompatibilityTestCase {
             + "<id name=\"studentId\" column=\"student_id\">" + "<generator class=\"assigned\"/>" + "</id>"
             + "<property name=\"firstName\" column=\"first_name\"/>" + "<property name=\"lastName\" column=\"last_name\"/>"
             + "<property name=\"address\"/>"
-            + "</class></hibernate-mapping>";
+            + "</class>"
+            + "<class name=\"org.jboss.as.test.compat.jpa.hibernate.transformer.Gene\" table=\"GENE\">"
+            + "<id name=\"id\">" + "<generator class=\"assigned\"/>" + "</id>"
+            + "<property name=\"state\" type=\"org.jboss.as.test.compat.jpa.hibernate.transformer.StateType\"/>"
+            + "</class>" + "</hibernate-mapping>";
 
     @ArquillianResource
     private static InitialContext iniCtx;
@@ -91,10 +95,13 @@ public class VerifyHibernate51CompatibilityTestCase {
 
         JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "beans.jar");
         lib.addClasses(SFSBHibernateSessionFactory.class);
-        ear.addAsModule(lib);
+        ear.addAsModule( lib );
 
         lib = ShrinkWrap.create(JavaArchive.class, "entities.jar");
         lib.addClasses(Student.class);
+        lib.addClasses(Gene.class);
+        lib.addClasses(State.class);
+        lib.addClasses(StateType.class);
         lib.addAsResource(new StringAsset(testmapping), "testmapping.hbm.xml");
         lib.addAsResource(new StringAsset(hibernate_cfg), "hibernate.cfg.xml");
         ear.addAsLibraries(lib);
@@ -401,4 +408,21 @@ public class VerifyHibernate51CompatibilityTestCase {
             assertEquals( i, ( (Student) results.get( resultIndex ) ).getStudentId() );
         }
     }
+
+    @Test
+    public void testUserTypeImplemented() throws Exception {
+
+        SFSBHibernateSessionFactory sfsb = lookup("SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            sfsb.createGene( 1, State.DORMANT );
+            final Gene gene = sfsb.getGene( 1 );
+            assertEquals( State.DORMANT, gene.getState() );
+        } finally {
+            sfsb.cleanup();
+        }
+    }
+
+
 }


### PR DESCRIPTION
…serType

Adds a test, testUserTypeImplemented, for an entity with a property mapped using a user type that implements org.hibernate.type.UserType: StateType 

VerifyHibernate51CompatibilityTestCase#testUserTypeImplemented calls:

SFSBHibernateSessionFactory#createGene, which results in Hibernate calling StateType#nullSafeSet.
SFSBHibernateSessionFactory#getGene, which results in Hibernate calling StateType#nullSafeGet.

Test will fail calling SFSBHibernateSessionFactory#createGene:

Caused by: java.lang.RuntimeException: java.lang.AbstractMethodError: org.jboss.as.test.compat.jpa.hibernate.transformer.StateType.nullSafeSet(Ljava/sql
/PreparedStatement;Ljava/lang/Object;ILorg/hibernate/engine/spi/SharedSessionContractImplementor;)

After that is fixed by the compatibility transformer, SFSBHibernateSessionFactory#getGene will fail due to AbstractMethodError calling StateType#nullSafeSet.
