### PR TITLE
Hibernate transformer enable options

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPAClassFileTransformerProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPAClassFileTransformerProcessor.java
@@ -46,10 +46,10 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  */
 public class JPAClassFileTransformerProcessor implements DeploymentUnitProcessor {
 
-    private static final boolean hibernate51CompatibilityTransformer = Boolean.parseBoolean(
+    private final boolean hibernate51CompatibilityTransformer = Boolean.parseBoolean(
             WildFlySecurityManager.getPropertyPrivileged("Hibernate51CompatibilityTransformer","false"));
 
-    static {
+    public JPAClassFileTransformerProcessor() {
         if(hibernate51CompatibilityTransformer) {
             ROOT_LOGGER.hibernate51CompatibilityTransformerEnabled();
         }

--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -67,6 +67,29 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-core-testsuite-shared</artifactId>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
             <scope>test</scope>

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/VerifyHibernate51CompatibilityJDSEnabledTransformerTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/VerifyHibernate51CompatibilityJDSEnabledTransformerTestCase.java
@@ -1,0 +1,51 @@
+/*
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.jboss.as.test.compat.jpa.hibernate.transformer;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Enable Hibernate bytecode transformer for application with jboss-deployment-structure.xml
+ */
+@RunWith(Arquillian.class)
+public class VerifyHibernate51CompatibilityJDSEnabledTransformerTestCase
+        extends AbstractVerifyHibernate51CompatibilityTestCase {
+
+    @Deployment
+    public static Archive<?> deploy() {
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class,
+                VerifyHibernate51CompatibilityJDSEnabledTransformerTestCase.class.getName() + ".ear");
+        ear.addAsLibraries(getLib());
+
+        WebArchive war = getWar();
+        war.addClasses(VerifyHibernate51CompatibilityJDSEnabledTransformerTestCase.class);
+        ear.addAsModule(war);
+
+        ear.addAsManifestResource(VerifyHibernate51CompatibilityJDSEnabledTransformerTestCase.class.getPackage(),
+                "jboss-deployment-structure.xml","jboss-deployment-structure.xml");
+        return ear;
+    }
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/VerifyHibernate51CompatibilityPropertyEnabledTransformerTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/VerifyHibernate51CompatibilityPropertyEnabledTransformerTestCase.java
@@ -1,0 +1,82 @@
+/*
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.jboss.as.test.compat.jpa.hibernate.transformer;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Enable Hibernate bytecode transformer globally with system-property Hibernate51CompatibilityTransformer=true
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(VerifyHibernate51CompatibilityPropertyEnabledTransformerTestCase.EnableHibernateBytecodeTransformerSetupTask.class)
+public class VerifyHibernate51CompatibilityPropertyEnabledTransformerTestCase
+        extends AbstractVerifyHibernate51CompatibilityTestCase {
+
+    @Deployment
+    public static Archive<?> deploy() {
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class,
+                VerifyHibernate51CompatibilityPropertyEnabledTransformerTestCase.class.getName() + ".ear");
+        ear.addAsLibraries(getLib());
+
+        WebArchive war = getWar();
+        war.addClasses(VerifyHibernate51CompatibilityPropertyEnabledTransformerTestCase.class);
+        ear.addAsModule(war);
+
+        ear.addAsManifestResource(new StringAsset("<jboss-deployment-structure>" + " <deployment>" + " <dependencies>"
+                + " <module name=\"org.hibernate\" export=\"true\" />"
+                + " <module name=\"com.h2database.h2\" />" + " <module name=\"org.slf4j\"/>" + " </dependencies>"
+                + " </deployment>"
+                + "</jboss-deployment-structure>"), "jboss-deployment-structure.xml");
+        return ear;
+    }
+
+    public static class EnableHibernateBytecodeTransformerSetupTask implements ServerSetupTask {
+        private static final ModelNode PROP_ADDR = new ModelNode()
+                .add("system-property", "Hibernate51CompatibilityTransformer");
+
+        @Override
+        public void setup(ManagementClient managementClient, String s) throws Exception {
+            ModelNode op = Operations.createAddOperation(PROP_ADDR);
+            op.get("value").set("true");
+            managementClient.getControllerClient().execute(op);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String s) throws Exception {
+            ModelNode op = Operations.createRemoveOperation(PROP_ADDR);
+            managementClient.getControllerClient().execute(op);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        }
+    }
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/jboss-deployment-structure.xml
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/jboss-deployment-structure.xml
@@ -4,15 +4,11 @@
             <transformer class="org.jboss.as.hibernate.Hibernate51CompatibilityTransformer"/>
         </transformers>
         <dependencies>
+            <module name="org.hibernate" export="true" />
             <module name="com.h2database.h2" />
             <module name="org.slf4j"/>
         </dependencies>
     </deployment>
-    <sub-deployment name="beans.jar">
-        <transformers>
-            <transformer class="org.jboss.as.hibernate.Hibernate51CompatibilityTransformer"/>
-        </transformers>
-    </sub-deployment>
     <sub-deployment name="main.war">
         <transformers>
             <transformer class="org.jboss.as.hibernate.Hibernate51CompatibilityTransformer"/>


### PR DESCRIPTION
contains 3 commits

1. simplifies test a little bit
2. changes when system property is read to allow changing it with server reload instead of full restart
3. splits test to two tests, one for transformer enabled with system property and second for transformer enabled in application with jboss-deployment-structure.xml

testCollectionUserTypeImplementedPersistentBagExtended still fails for me, I'll try to pull ORM 5.3 branch and I'll see

@gsmet @gbadner this might cause some conflicts if you work on tests. @scottmarlow can wait with merging and I'll rebase it later 