### PR TITLE
[WFLY-20564] Enhance existing 'deployed driver' test to have the driv…

### DIFF
--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/datasource/AddDataSourceOperationsUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/datasource/AddDataSourceOperationsUnitTestCase.java
@@ -20,6 +20,7 @@ import org.jboss.as.test.integration.management.jca.DsMgmtTestBase;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
@@ -42,7 +43,10 @@ public class AddDataSourceOperationsUnitTestCase extends DsMgmtTestBase{
     public static Archive<?> getDeployment() {
         return ShrinkWrap.create(JavaArchive.class, JDBC_DRIVER_NAME)
                 .addClass(TestDriver.class)
-                .addAsServiceProvider(Driver.class, TestDriver.class);
+                .addAsServiceProvider(Driver.class, TestDriver.class)
+                // simulate a driver that includes a main class, as WF would treat such a deployment
+                // as an appclient module. So see what happens.
+                .setManifest(new StringAsset("Main-Class: " + TestDriver.class.getName()));
     }
 
     @Test

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/datasource/TestDriver.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/datasource/TestDriver.java
@@ -66,4 +66,12 @@ public class TestDriver implements Driver {
     public Logger getParentLogger() throws SQLFeatureNotSupportedException {
         throw new SQLFeatureNotSupportedException();
     }
+
+    /**
+     * A no-op main method so this 'driver' can simulate real ones that have a main.
+     * @param args the args
+     */
+    public static void main(String[] args) {
+        // do nothing
+    }
 }


### PR DESCRIPTION
…er expose a Main-Class

This takes an existing test that deploys a driver and 'enhances' the driver to simulate what happened on https://issues.redhat.com/browse/WFLY-20564 with the postgresql-42.7.4.jar.

Without your fix in your WFLY-20564_fixnpe branch this test fails with the failure reported in the WFLY-20564 bug report. With your fix this test passes.
